### PR TITLE
chore: upstream=6.4.0,add=alpine_3.24,debian_forky,ubuntu_questing,drop=debian_bookworm

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,22 +9,26 @@ builds:
     archs:
       - linux/amd64
       - linux/arm64
+  - os: alpine_3.24
+    archs:
+      - linux/amd64
+      - linux/arm64
   - os: archlinux_latest
     archs:
       - linux/amd64
-  - os: debian_bookworm
-    archs:
-      - linux/amd64
-      - linux/arm64
-  - os: debian_bookworm-slim
-    archs:
-      - linux/amd64
-      - linux/arm64
   - os: debian_trixie
     archs:
       - linux/amd64
       - linux/arm64
   - os: debian_trixie-slim
+    archs:
+      - linux/amd64
+      - linux/arm64
+  - os: debian_forky
+    archs:
+      - linux/amd64
+      - linux/arm64
+  - os: debian_forky-slim
     archs:
       - linux/amd64
       - linux/arm64
@@ -36,6 +40,10 @@ builds:
     archs:
       - linux/amd64
       - linux/arm64
+  - os: ubuntu_questing
+    archs:
+      - linux/amd64
+      - linux/arm64
 upstream:
     repo: ghcr.io/bradfordwagner/ansible
-    tag: 6.3.1
+    tag: 6.4.0


### PR DESCRIPTION
Propagate upstream ansible 6.4.0 changes: add alpine_3.24, debian_forky, debian_forky-slim, ubuntu_questing; drop debian_bookworm and debian_bookworm-slim.